### PR TITLE
fix(food-tracker): fix manual food entry + migration runner

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -21,6 +21,12 @@ DB_SSL_MODE=require
 DB_MAX_OPEN_CONNS=25
 DB_MAX_IDLE_CONNS=5
 
+# Migration baseline: mark all migrations ≤ N as already applied without running them.
+# Set this once when deploying the migration runner to an existing database.
+# Leave at 0 (default) for brand-new databases — all migrations will run normally.
+# Example: DB_MIGRATION_BASELINE=42
+DB_MIGRATION_BASELINE=0
+
 # JWT Configuration
 JWT_SECRET=your-secret-key-change-in-production
 

--- a/apps/api/cmd/server/main.go
+++ b/apps/api/cmd/server/main.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/burcev/api/internal/config"
 	"github.com/burcev/api/internal/modules/admin"
-	"github.com/burcev/api/migrations"
 	"github.com/burcev/api/internal/modules/auth"
 	"github.com/burcev/api/internal/modules/chat"
 	"github.com/burcev/api/internal/modules/content"
@@ -30,6 +29,7 @@ import (
 	"github.com/burcev/api/internal/shared/openrouter"
 	"github.com/burcev/api/internal/shared/storage"
 	"github.com/burcev/api/internal/shared/ws"
+	"github.com/burcev/api/migrations"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )

--- a/apps/api/cmd/server/main.go
+++ b/apps/api/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/burcev/api/internal/config"
 	"github.com/burcev/api/internal/modules/admin"
+	"github.com/burcev/api/migrations"
 	"github.com/burcev/api/internal/modules/auth"
 	"github.com/burcev/api/internal/modules/chat"
 	"github.com/burcev/api/internal/modules/content"
@@ -70,6 +71,12 @@ func main() {
 		"database", cfg.DatabaseName,
 		"max_open_conns", cfg.MaxOpenConns,
 	)
+
+	// Run database migrations
+	migrator := database.NewMigrator(db, migrations.FS, log)
+	if err := migrator.Run(context.Background(), cfg.MigrationBaseline); err != nil {
+		log.Fatal("Database migration failed", "error", err)
+	}
 
 	// Initialize email service
 	emailService, err := email.NewService(email.Config{

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/jackc/pgx/v5 v5.8.0
+	github.com/jackc/pgx/v5 v5.9.0
 	github.com/joho/godotenv v1.5.1
 	github.com/leanovate/gopter v0.2.11
 	github.com/stretchr/testify v1.11.1

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -227,6 +227,8 @@ github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7Ulw
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
 github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
+github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
+github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -85,6 +85,9 @@ type Config struct {
 	OpenRouterModel           string
 	FoodRecognitionDailyLimit int
 
+	// Migrations
+	MigrationBaseline int
+
 	// Logging
 	LogLevel string
 }
@@ -169,6 +172,8 @@ func Load() (*Config, error) {
 		OpenRouterAPIKey:          getEnv("OPENROUTER_API_KEY", ""),
 		OpenRouterModel:           getEnv("OPENROUTER_MODEL", "anthropic/claude-sonnet-4"),
 		FoodRecognitionDailyLimit: getEnvAsInt("FOOD_RECOGNITION_DAILY_LIMIT", 3),
+
+		MigrationBaseline: getEnvAsInt("DB_MIGRATION_BASELINE", 0),
 
 		LogLevel: getEnv("LOG_LEVEL", "info"),
 	}

--- a/apps/api/internal/modules/food-tracker/service.go
+++ b/apps/api/internal/modules/food-tracker/service.go
@@ -673,7 +673,47 @@ func (s *Service) getFoodItemByID(ctx context.Context, foodID string) (*FoodItem
 			})
 			return nil, fmt.Errorf("ошибка при получении продукта: %w", err)
 		}
-		// Not found in food_items — fall through to products
+
+		// Not found in food_items — check user_foods (manual entries created before the dual-write fix).
+		var uf UserFood
+		ufErr := s.db.QueryRowContext(ctx, `
+			SELECT id, name, brand, calories_per_100, protein_per_100, fat_per_100, carbs_per_100,
+			       serving_size, serving_unit
+			FROM user_foods WHERE id = $1
+		`, foodID).Scan(
+			&uf.ID, &uf.Name, &uf.Brand,
+			&uf.CaloriesPer100, &uf.ProteinPer100, &uf.FatPer100, &uf.CarbsPer100,
+			&uf.ServingSize, &uf.ServingUnit,
+		)
+		if ufErr == nil {
+			// Backfill food_items so the FK in food_entries is satisfied on next CreateEntry.
+			_, _ = s.db.ExecContext(ctx, `
+				INSERT INTO food_items (id, name, brand, category, serving_size, serving_unit,
+				                        calories_per_100, protein_per_100, fat_per_100, carbs_per_100,
+				                        source, verified, created_at, updated_at)
+				VALUES ($1, $2, $3, 'custom', $4, $5, $6, $7, $8, $9, 'user', false, NOW(), NOW())
+				ON CONFLICT (id) DO NOTHING
+			`, uf.ID, uf.Name, uf.Brand, uf.ServingSize, uf.ServingUnit,
+				uf.CaloriesPer100, uf.ProteinPer100, uf.FatPer100, uf.CarbsPer100)
+
+			item := &FoodItem{
+				ID:             uf.ID,
+				Name:           uf.Name,
+				Brand:          uf.Brand,
+				Category:       "custom",
+				ServingSize:    uf.ServingSize,
+				ServingUnit:    uf.ServingUnit,
+				CaloriesPer100: uf.CaloriesPer100,
+				ProteinPer100:  uf.ProteinPer100,
+				FatPer100:      uf.FatPer100,
+				CarbsPer100:    uf.CarbsPer100,
+				Source:         SourceUser,
+			}
+			item.PopulateNutrition()
+			return item, nil
+		}
+
+		// Not found in food_items or user_foods — fall through to products
 	}
 
 	// Try products table (integer IDs)
@@ -2131,12 +2171,27 @@ func (s *Service) CreateUserFood(ctx context.Context, userID int64, req *CreateU
 		brand = &req.Brand
 	}
 
+	foodID := uuid.New().String()
+
+	// Mirror into food_items so food_entries.food_id FK is satisfied.
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO food_items (id, name, brand, category, serving_size, serving_unit,
+		                        calories_per_100, protein_per_100, fat_per_100, carbs_per_100,
+		                        source, verified, created_at, updated_at)
+		VALUES ($1, $2, $3, 'custom', $4, $5, $6, $7, $8, $9, 'user', false, NOW(), NOW())
+		ON CONFLICT (id) DO NOTHING
+	`, foodID, req.Name, brand, servingSize, servingUnit,
+		req.CaloriesPer100, req.ProteinPer100, req.FatPer100, req.CarbsPer100)
+	if err != nil {
+		return nil, fmt.Errorf("ошибка при зеркалировании продукта в food_items: %w", err)
+	}
+
 	var food UserFood
-	err := s.db.QueryRowContext(ctx, `
-		INSERT INTO user_foods (user_id, name, brand, calories_per_100, protein_per_100, fat_per_100, carbs_per_100, serving_size, serving_unit)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	err = s.db.QueryRowContext(ctx, `
+		INSERT INTO user_foods (id, user_id, name, brand, calories_per_100, protein_per_100, fat_per_100, carbs_per_100, serving_size, serving_unit)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		RETURNING id, user_id, name, brand, calories_per_100, protein_per_100, fat_per_100, carbs_per_100, serving_size, serving_unit, source_food_id, created_at, updated_at
-	`, userID, req.Name, brand, req.CaloriesPer100, req.ProteinPer100, req.FatPer100, req.CarbsPer100, servingSize, servingUnit).Scan(
+	`, foodID, userID, req.Name, brand, req.CaloriesPer100, req.ProteinPer100, req.FatPer100, req.CarbsPer100, servingSize, servingUnit).Scan(
 		&food.ID, &food.UserID, &food.Name, &food.Brand,
 		&food.CaloriesPer100, &food.ProteinPer100, &food.FatPer100, &food.CarbsPer100,
 		&food.ServingSize, &food.ServingUnit, &food.SourceFoodID,

--- a/apps/api/internal/shared/database/migrator.go
+++ b/apps/api/internal/shared/database/migrator.go
@@ -1,0 +1,258 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// migrationLogger is the subset of logger methods used by Migrator.
+type migrationLogger interface {
+	Infow(msg string, keysAndValues ...any)
+	Warnw(msg string, keysAndValues ...any)
+	Errorw(msg string, keysAndValues ...any)
+}
+
+// migration holds a parsed migration file ready to apply.
+type migration struct {
+	Version int
+	Name    string
+	SQL     string
+}
+
+// Migrator applies SQL migration files in version order and tracks applied
+// versions in the schema_migrations table.
+type Migrator struct {
+	db  *DB
+	fs  fs.FS
+	log migrationLogger
+}
+
+// NewMigrator creates a Migrator. migrationsFS must contain *_up.sql files
+// named with a numeric prefix, e.g. "001_init_up.sql".
+func NewMigrator(db *DB, migrationsFS fs.FS, log migrationLogger) *Migrator {
+	return &Migrator{db: db, fs: migrationsFS, log: log}
+}
+
+// Run ensures schema_migrations exists, optionally seeds it with a baseline,
+// then applies all pending up-migrations in version order.
+//
+// baseline: if schema_migrations is empty and baseline > 0, all versions up to
+// and including baseline are recorded as already applied without running their
+// SQL (for brownfield databases that were migrated manually).
+func (m *Migrator) Run(ctx context.Context, baseline int) error {
+	if err := m.ensureMigrationsTable(ctx); err != nil {
+		return err
+	}
+
+	applied, seeded, err := m.loadApplied(ctx)
+	if err != nil {
+		return err
+	}
+
+	pending, err := m.loadPending(applied)
+	if err != nil {
+		return err
+	}
+
+	if len(pending) == 0 {
+		m.log.Infow("Migrations: all up to date", "applied", len(applied))
+		return nil
+	}
+
+	// On first run with an empty table, seed baseline versions without executing SQL.
+	if !seeded && baseline > 0 {
+		if err := m.seedBaseline(ctx, pending, baseline); err != nil {
+			return err
+		}
+		// Reload so we only apply truly pending migrations.
+		applied, _, err = m.loadApplied(ctx)
+		if err != nil {
+			return err
+		}
+		pending, err = m.loadPending(applied)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(pending) == 0 {
+		m.log.Infow("Migrations: all up to date after baseline seed", "applied", len(applied))
+		return nil
+	}
+
+	m.log.Infow("Migrations: applying pending", "count", len(pending))
+
+	for _, mg := range pending {
+		if err := m.apply(ctx, mg); err != nil {
+			return fmt.Errorf("migration %03d_%s failed: %w", mg.Version, mg.Name, err)
+		}
+		m.log.Infow("Migration applied", "version", mg.Version, "name", mg.Name)
+	}
+
+	m.log.Infow("Migrations: complete", "applied", len(pending))
+	return nil
+}
+
+// Applied returns all versions recorded in schema_migrations.
+func (m *Migrator) Applied(ctx context.Context) ([]int, error) {
+	applied, _, err := m.loadApplied(ctx)
+	if err != nil {
+		return nil, err
+	}
+	versions := make([]int, 0, len(applied))
+	for v := range applied {
+		versions = append(versions, v)
+	}
+	sort.Ints(versions)
+	return versions, nil
+}
+
+// ensureMigrationsTable creates schema_migrations if it does not exist.
+func (m *Migrator) ensureMigrationsTable(ctx context.Context) error {
+	_, err := m.db.DB.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			version    INTEGER     PRIMARY KEY,
+			name       TEXT        NOT NULL,
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`)
+	if err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+	return nil
+}
+
+// loadApplied returns the set of applied versions and whether the table had
+// any rows (seeded = true means the table was not brand new / empty).
+func (m *Migrator) loadApplied(ctx context.Context) (map[int]struct{}, bool, error) {
+	rows, err := m.db.DB.QueryContext(ctx,
+		`SELECT version FROM schema_migrations ORDER BY version`)
+	if err != nil {
+		return nil, false, fmt.Errorf("query schema_migrations: %w", err)
+	}
+	defer rows.Close()
+
+	applied := make(map[int]struct{})
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			return nil, false, err
+		}
+		applied[v] = struct{}{}
+	}
+	return applied, len(applied) > 0, rows.Err()
+}
+
+// loadPending returns all up-migrations not yet in applied, sorted by version.
+func (m *Migrator) loadPending(applied map[int]struct{}) ([]migration, error) {
+	entries, err := fs.ReadDir(m.fs, ".")
+	if err != nil {
+		return nil, fmt.Errorf("read migrations dir: %w", err)
+	}
+
+	var pending []migration
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), "_up.sql") {
+			continue
+		}
+		mg, err := parseMigrationFile(m.fs, e.Name())
+		if err != nil {
+			m.log.Warnw("Skipping unparseable migration file", "file", e.Name(), "error", err)
+			continue
+		}
+		if _, ok := applied[mg.Version]; !ok {
+			pending = append(pending, mg)
+		}
+	}
+
+	sort.Slice(pending, func(i, j int) bool {
+		return pending[i].Version < pending[j].Version
+	})
+	return pending, nil
+}
+
+// seedBaseline records all pending migrations with version ≤ baseline as
+// already applied, without executing their SQL.
+func (m *Migrator) seedBaseline(ctx context.Context, pending []migration, baseline int) error {
+	m.log.Infow("Migrations: seeding baseline", "baseline", baseline)
+
+	tx, err := m.db.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin baseline tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	seeded := 0
+	for _, mg := range pending {
+		if mg.Version > baseline {
+			continue
+		}
+		_, err := tx.ExecContext(ctx,
+			`INSERT INTO schema_migrations (version, name, applied_at) VALUES ($1, $2, $3)
+			 ON CONFLICT (version) DO NOTHING`,
+			mg.Version, mg.Name, time.Now())
+		if err != nil {
+			return fmt.Errorf("seed baseline version %d: %w", mg.Version, err)
+		}
+		seeded++
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit baseline seed: %w", err)
+	}
+
+	m.log.Infow("Migrations: baseline seeded", "count", seeded)
+	return nil
+}
+
+// apply runs a single migration inside a transaction and records it.
+func (m *Migrator) apply(ctx context.Context, mg migration) error {
+	tx, err := m.db.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(ctx, mg.SQL); err != nil {
+		return fmt.Errorf("exec sql: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO schema_migrations (version, name) VALUES ($1, $2)`,
+		mg.Version, mg.Name); err != nil {
+		return fmt.Errorf("record migration: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// parseMigrationFile reads and parses a *_up.sql file from the FS.
+// Filename format: NNN_name_up.sql  (NNN = zero-padded integer version)
+func parseMigrationFile(migrationsFS fs.FS, filename string) (migration, error) {
+	// Strip "_up.sql" suffix, then split on first "_" to get version
+	base := strings.TrimSuffix(filename, "_up.sql")
+	parts := strings.SplitN(base, "_", 2)
+	if len(parts) < 2 {
+		return migration{}, fmt.Errorf("unexpected filename format: %s", filename)
+	}
+
+	version, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return migration{}, fmt.Errorf("non-numeric version prefix in %s", filename)
+	}
+
+	sql, err := fs.ReadFile(migrationsFS, filename)
+	if err != nil {
+		return migration{}, fmt.Errorf("read %s: %w", filename, err)
+	}
+
+	return migration{
+		Version: version,
+		Name:    parts[1],
+		SQL:     string(sql),
+	}, nil
+}

--- a/apps/api/migrations/embed.go
+++ b/apps/api/migrations/embed.go
@@ -1,0 +1,8 @@
+package migrations
+
+import "embed"
+
+// FS contains all migration SQL files embedded in the binary.
+//
+//go:embed *.sql
+var FS embed.FS

--- a/apps/web/src/features/food-tracker/components/ManualEntryForm.tsx
+++ b/apps/web/src/features/food-tracker/components/ManualEntryForm.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useCallback } from 'react';
 import { Save, X } from 'lucide-react';
+import toast from 'react-hot-toast';
 import { apiClient } from '@/shared/utils/api-client';
 import { getApiUrl } from '@/config/api';
 import type { FoodItem } from '../types';
@@ -160,6 +161,7 @@ export function ManualEntryForm({
             onSubmit(food);
         } catch (error) {
             console.error('Failed to create user food:', error);
+            toast.error('Не удалось создать продукт. Попробуйте ещё раз.');
         } finally {
             setIsSubmitting(false);
         }


### PR DESCRIPTION
## Summary

- **Root cause**: Migration `036_fix_user_foods_schema` was never applied to prod — `user_foods` table had old column names (`calories` instead of `calories_per_100`, missing `brand`/`source_food_id`), causing 500 on every manual food entry creation
- **Second bug**: `CreateUserFood` only wrote to `user_foods`, but `food_entries.food_id` has a FK → `food_items`. Created food UUID was invisible to `CreateEntry`, causing "Продукт не найден"
- **Migration runner**: Added `Migrator` that applies pending `*_up.sql` files on server startup and tracks state in `schema_migrations` — prevents this class of bug in the future

## Changes

**Backend**
- `migrations/embed.go` — embeds all `*.sql` files into the binary
- `internal/shared/database/migrator.go` — migration runner: creates `schema_migrations`, applies pending migrations in order, supports baseline seeding for brownfield DBs
- `internal/modules/food-tracker/service.go`:
  - `CreateUserFood` now generates UUID upfront and dual-writes to `food_items` + `user_foods` (same UUID) so FK is satisfied
  - `getFoodItemByID` gains fallback to `user_foods` with auto-backfill to `food_items` for records predating this fix
- `cmd/server/main.go` — runs migrator on startup before HTTP server starts
- `internal/config/config.go` + `.env.example` — `DB_MIGRATION_BASELINE` for brownfield seeding

**Frontend**
- `ManualEntryForm.tsx` — `toast.error(...)` in catch block so user sees API failures instead of silent spinner

**Database (applied manually)**
- Migration `036` applied to prod and dev
- `schema_migrations` table created and seeded with all 42 existing versions on both environments
- 2 existing `user_foods` records on prod backfilled into `food_items`

## Test plan

- [ ] Manually create a food item via "Ручной ввод" tab and save a food entry
- [ ] Verify food entry appears in the daily log with correct КБЖУ
- [ ] Verify server logs show "Migrations: all up to date" on startup
- [ ] Verify `schema_migrations` table on prod has 42 rows after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)