### PR TITLE
fix(nginx): CSP header for prod + H2C smuggling mitigation

### DIFF
--- a/deploy/nginx/burcev.team.conf
+++ b/deploy/nginx/burcev.team.conf
@@ -5,6 +5,17 @@
 # IMPORTANT: /api/v1/ goes to Go API, everything else to Next.js
 # Do NOT use /api/ — it would catch Next.js /api/health route
 
+# Restrict Upgrade to websocket only — prevents H2C smuggling (CWE-444).
+# Used only in the /ws location; all other locations omit Upgrade entirely.
+map $http_upgrade $ws_upgrade {
+    "websocket" "websocket";
+    default     "";
+}
+map $ws_upgrade $ws_connection {
+    "websocket" "upgrade";
+    default     "close";
+}
+
 server {
     listen 80;
     listen [::]:80;
@@ -41,17 +52,18 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' wss://burcev.team https:; frame-ancestors 'none';" always;
 
+    # Variable indirection defers Docker DNS resolution so nginx starts before
+    # containers are up. Values are hardcoded service names, not attacker-controlled.
     resolver 127.0.0.11 valid=10s ipv6=off;
     set $web_upstream burcev-prod:3069;
     set $api_upstream burcev-api-prod:4000;
 
-    # Go API: /api/v1/* only
+    # Go API: /api/v1/* — REST only, no WebSocket upgrade needed
     location /api/v1/ {
-        proxy_pass http://$api_upstream;
+        proxy_pass http://$api_upstream; # nosemgrep: hardcoded Docker service name
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -60,9 +72,23 @@ server {
         proxy_read_timeout 90s;
     }
 
+    # WebSocket: /ws -> Go API (only location that forwards Upgrade)
+    location = /ws {
+        proxy_pass http://$api_upstream; # nosemgrep: hardcoded Docker service name
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $ws_upgrade; # nosemgrep: filtered to websocket-only via map above
+        proxy_set_header Connection $ws_connection;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+
     # Go API health check
     location = /health {
-        proxy_pass http://$api_upstream;
+        proxy_pass http://$api_upstream; # nosemgrep: hardcoded Docker service name
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -71,16 +97,14 @@ server {
     }
 
     # Next.js: everything else (including /api/health)
+    # Production Next.js uses HTTP streaming, not WebSocket — no Upgrade headers needed
     location / {
-        proxy_pass http://$web_upstream;
+        proxy_pass http://$web_upstream; # nosemgrep: hardcoded Docker service name
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 90s;
         proxy_connect_timeout 90s;
     }

--- a/deploy/nginx/new.burcev.team.conf
+++ b/deploy/nginx/new.burcev.team.conf
@@ -105,7 +105,6 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $ws_upgrade;
         proxy_read_timeout 90s;
         proxy_connect_timeout 90s;
     }

--- a/deploy/nginx/new.burcev.team.conf
+++ b/deploy/nginx/new.burcev.team.conf
@@ -5,6 +5,17 @@
 # IMPORTANT: /api/v1/ goes to Go API, everything else to Next.js
 # Do NOT use /api/ — it would catch Next.js /api/health route
 
+# Restrict Upgrade to websocket only — prevents H2C smuggling (CWE-444).
+# Used only in the /ws location; all other locations omit Upgrade entirely.
+map $http_upgrade $ws_upgrade {
+    "websocket" "websocket";
+    default     "";
+}
+map $ws_upgrade $ws_connection {
+    "websocket" "upgrade";
+    default     "close";
+}
+
 server {
     listen 80;
     listen [::]:80;
@@ -43,16 +54,16 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' wss://new.burcev.team https:; frame-ancestors 'none';" always;
 
+    # Variable indirection defers Docker DNS resolution so nginx starts before
+    # containers are up. Values are hardcoded service names, not attacker-controlled.
     resolver 127.0.0.11 valid=10s ipv6=off;
     set $web_upstream burcev-dev:3069;
     set $api_upstream burcev-api-dev:4000;
 
-    # Go API: /api/v1/* only
+    # Go API: /api/v1/* — REST only, no WebSocket upgrade needed
     location /api/v1/ {
-        proxy_pass http://$api_upstream;
+        proxy_pass http://$api_upstream; # nosemgrep: hardcoded Docker service name
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -61,12 +72,12 @@ server {
         proxy_read_timeout 90s;
     }
 
-    # WebSocket: /ws -> Go API
+    # WebSocket: /ws -> Go API (only location that forwards Upgrade)
     location = /ws {
-        proxy_pass http://$api_upstream;
+        proxy_pass http://$api_upstream; # nosemgrep: hardcoded Docker service name
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Upgrade $ws_upgrade; # nosemgrep: filtered to websocket-only via map above
+        proxy_set_header Connection $ws_connection;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -77,7 +88,7 @@ server {
 
     # Go API health check
     location = /health {
-        proxy_pass http://$api_upstream;
+        proxy_pass http://$api_upstream; # nosemgrep: hardcoded Docker service name
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -86,16 +97,15 @@ server {
     }
 
     # Next.js: everything else (including /api/health)
+    # Production Next.js uses HTTP streaming, not WebSocket — no Upgrade headers needed
     location / {
-        proxy_pass http://$web_upstream;
+        proxy_pass http://$web_upstream; # nosemgrep: hardcoded Docker service name
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
+        proxy_cache_bypass $ws_upgrade;
         proxy_read_timeout 90s;
         proxy_connect_timeout 90s;
     }


### PR DESCRIPTION
## Summary

- **burcev.team.conf**: Added `Content-Security-Policy` header (was present on dev `new.burcev.team.conf` but missing from prod)
- **Both configs**: Added `map` block restricting `Upgrade` to `websocket`-only to prevent H2C smuggling (CWE-444)
- **Both configs**: Removed `Upgrade`/`Connection` forwarding from `/api/v1/` (REST-only) and `/` (Next.js production uses HTTP streaming); WebSocket upgrade now only forwarded in the dedicated `/ws` location
- **burcev.team.conf**: Added missing `/ws` WebSocket location (existed in dev config but not prod)

## Why
H2C smuggling allows `Upgrade: h2c` to establish cleartext HTTP/2 tunnels to backends, bypassing reverse proxy access controls. The fix is a two-variable `map` that passes "websocket" through and drops everything else.

The dynamic-host and `internal`-directive semgrep warnings are false positives for a public reverse proxy — upstream values are hardcoded Docker service names set by `set $var` above, not attacker-controlled.

## Test plan
- [ ] `curl -sI https://burcev.team | grep content-security-policy` returns the CSP header
- [ ] WebSocket connections to `wss://burcev.team/ws` still work after deploy
- [ ] `Upgrade: h2c` request to `/api/v1/` does NOT get forwarded to backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)