### PR TITLE
fix(content): content S3 path prefix + DB pool resilience

### DIFF
--- a/apps/api/cmd/server/main.go
+++ b/apps/api/cmd/server/main.go
@@ -159,7 +159,7 @@ func main() {
 			Bucket:          cfg.ContentS3Bucket,
 			Region:          cfg.ContentS3Region,
 			Endpoint:        cfg.ContentS3Endpoint,
-			PathPrefix:      cfg.S3PathPrefix,
+			PathPrefix:      cfg.ContentS3PathPrefix,
 		}, log)
 		if err != nil {
 			log.Error("Failed to initialize content S3 client", "error", err)

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -69,8 +69,12 @@ type Config struct {
 	ContentS3Bucket          string
 	ContentS3Region          string
 	ContentS3Endpoint        string
+	// ContentS3PathPrefix overrides S3PathPrefix for content only.
+	// Defaults to "" because the curator-content bucket has no path prefix
+	// (files live at content/{uuid}/body.md, not prod/content/...).
+	ContentS3PathPrefix string
 
-	// S3 Path Prefix (dev/ or prod/ — applied to all S3 clients)
+	// S3 Path Prefix (dev/ or prod/ — applied to all S3 clients except content)
 	S3PathPrefix string
 
 	// Food Photos S3 — falls back to generic S3_* vars
@@ -158,6 +162,8 @@ func Load() (*Config, error) {
 		ContentS3Bucket:          getEnvWithFallback("CONTENT_S3_BUCKET", "S3_BUCKET", "curator-content"),
 		ContentS3Region:          getEnvWithFallback("CONTENT_S3_REGION", "S3_REGION", "ru-central1"),
 		ContentS3Endpoint:        getEnvWithFallback("CONTENT_S3_ENDPOINT", "S3_ENDPOINT", "https://storage.yandexcloud.net"),
+		// Default to "" — content files have no prefix in the curator-content bucket
+		ContentS3PathPrefix: getEnv("CONTENT_S3_PATH_PREFIX", ""),
 
 		S3PathPrefix: getEnv("S3_PATH_PREFIX", ""),
 

--- a/apps/api/internal/shared/database/postgres.go
+++ b/apps/api/internal/shared/database/postgres.go
@@ -63,11 +63,14 @@ func NewPostgres(cfg PostgresConfig) (*DB, error) {
 	// Register the driver and open connection
 	db := stdlib.OpenDB(*connConfig)
 
-	// Set connection pool settings
+	// Set connection pool settings.
+	// Short MaxLifetime (10m) ensures connections to the old primary are recycled
+	// quickly after a Yandex Cloud PG failover — the pool re-dials target_session_attrs=read-write
+	// and picks up the new primary rather than retrying the now-read-only node for up to an hour.
 	db.SetMaxOpenConns(cfg.MaxOpenConns)
 	db.SetMaxIdleConns(cfg.MaxIdleConns)
-	db.SetConnMaxLifetime(time.Hour)
-	db.SetConnMaxIdleTime(5 * time.Minute)
+	db.SetConnMaxLifetime(10 * time.Minute)
+	db.SetConnMaxIdleTime(2 * time.Minute)
 
 	// Verify connection
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -123,11 +126,11 @@ func NewPostgresFromURL(url string, maxOpenConns, maxIdleConns int) (*DB, error)
 
 	db := stdlib.OpenDB(*connConfig)
 
-	// Set connection pool settings
+	// Set connection pool settings — same as NewPostgres, see comment there.
 	db.SetMaxOpenConns(maxOpenConns)
 	db.SetMaxIdleConns(maxIdleConns)
-	db.SetConnMaxLifetime(time.Hour)
-	db.SetConnMaxIdleTime(5 * time.Minute)
+	db.SetConnMaxLifetime(10 * time.Minute)
+	db.SetConnMaxIdleTime(2 * time.Minute)
 
 	// Verify connection
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
## Summary

- **Critical fix**: Content article bodies were not loading because the global `S3_PATH_PREFIX=prod/` was applied to the `curator-content` bucket, but all files there are stored without a prefix (`content/{uuid}/body.md`). Added `ContentS3PathPrefix` config field (`CONTENT_S3_PATH_PREFIX` env, defaults to `""`) used exclusively for the content S3 client.
- **DB resilience**: Reduced `SetConnMaxLifetime` from 1h → 10m and `SetConnMaxIdleTime` from 5m → 2m to limit the stale-connection window after Yandex Cloud PG failover events (prod saw a ~25s outage from this today).

## Root cause (content)

Files in `curator-content` bucket:
```
content/3f529a17-ae23-41a2-ae1a-ae2d89f9d964/body.md  ✅ exists
```
Code was looking for:
```
prod/content/3f529a17-ae23-41a2-ae1a-ae2d89f9d964/body.md  ❌ not found
```

## Test plan
- [ ] After deploy: article bodies load on `burcev.team/content/`
- [ ] No `body not found in S3` warnings in prod logs
- [ ] Other S3 buckets (profiles, chat, food photos) still use `prod/` prefix correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)