### PR TITLE
fix(content): route cover images through Next.js optimizer

### DIFF
--- a/apps/api/internal/modules/content/service.go
+++ b/apps/api/internal/modules/content/service.go
@@ -1364,7 +1364,9 @@ func (s *Service) proxyExternalImages(ctx context.Context, articleID, coverURL, 
 		if err != nil || parsed.Scheme == "" || parsed.Scheme == "data" {
 			return false
 		}
-		return !strings.Contains(parsed.Host, s3Domain)
+		host := parsed.Hostname() // strips port if present
+		onS3 := host == s3Domain || strings.HasSuffix(host, "."+s3Domain)
+		return !onS3
 	}
 
 	isBlockedHost := func(hostname string) bool {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -18,6 +18,10 @@ const baseConfig: NextConfig = {
     deviceSizes: [640, 768, 1024, 1280, 1536],
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
     minimumCacheTTL: 60 * 60 * 24 * 7, // 7 days
+    remotePatterns: [
+      { protocol: 'https', hostname: 'images.unsplash.com' },
+      { protocol: 'https', hostname: 'storage.yandexcloud.net' },
+    ],
   },
   env: {
     NEXT_PUBLIC_APP_VERSION: appVersion,

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -20,7 +20,12 @@ const baseConfig: NextConfig = {
     minimumCacheTTL: 60 * 60 * 24 * 7, // 7 days
     remotePatterns: [
       { protocol: 'https', hostname: 'images.unsplash.com' },
-      { protocol: 'https', hostname: 'storage.yandexcloud.net' },
+      // Pin to specific buckets — prevents the Next.js image proxy from being
+      // used as an open proxy for arbitrary Yandex Cloud buckets.
+      { protocol: 'https', hostname: 'storage.yandexcloud.net', pathname: '/curator-content/**' },
+      { protocol: 'https', hostname: 'storage.yandexcloud.net', pathname: '/profiles-photos/**' },
+      { protocol: 'https', hostname: 'storage.yandexcloud.net', pathname: '/weekly-progress-photos/**' },
+      { protocol: 'https', hostname: 'storage.yandexcloud.net', pathname: '/food-photos/**' },
     ],
   },
   env: {

--- a/apps/web/src/features/content/components/FeedCard.tsx
+++ b/apps/web/src/features/content/components/FeedCard.tsx
@@ -41,7 +41,7 @@ export function FeedCard({ article }: FeedCardProps) {
                         alt={article.title}
                         fill
                         className="object-cover"
-                        unoptimized
+                        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                     />
                 </div>
             )}


### PR DESCRIPTION
## Summary
- Remove `unoptimized` prop from `FeedCard.tsx` — browser was fetching Unsplash URLs directly, causing `ERR_TIMED_OUT`
- Add `remotePatterns` to `next.config.ts` for `images.unsplash.com` and `storage.yandexcloud.net`
- Add `sizes` hint so the optimizer picks the right srcset variant

## Test plan
- [ ] Open `/content` — cover images load without ERR_TIMED_OUT
- [ ] Verify images are served via `/_next/image?url=...` in browser Network tab
- [ ] Content pages still render correctly on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)