### PR TITLE
fix: resolve prod errors — S3 ACL and curator SQL argument mismatch

### DIFF
--- a/apps/api/internal/modules/content/service.go
+++ b/apps/api/internal/modules/content/service.go
@@ -26,6 +26,7 @@ import (
 // S3Uploader defines the S3 operations used by the content service.
 type S3Uploader interface {
 	UploadFile(ctx context.Context, key string, data io.Reader, contentType string, fileSize int64) (string, error)
+	UploadPublicFile(ctx context.Context, key string, data io.Reader, contentType string, fileSize int64) (string, error)
 	GetFile(ctx context.Context, key string) ([]byte, error)
 	DeleteFile(ctx context.Context, key string) error
 }
@@ -839,7 +840,7 @@ func (s *Service) UploadCoverImage(ctx context.Context, file *multipart.FileHead
 	}
 	s3Key := fmt.Sprintf("cover-images/%s%s", uuid.New().String(), ext)
 
-	url, err := s.s3.UploadFile(ctx, s3Key, bytes.NewReader(data), contentType, int64(len(data)))
+	url, err := s.s3.UploadPublicFile(ctx, s3Key, bytes.NewReader(data), contentType, int64(len(data)))
 	if err != nil {
 		return "", fmt.Errorf("failed to upload cover image: %w", err)
 	}

--- a/apps/api/internal/modules/content/service_test.go
+++ b/apps/api/internal/modules/content/service_test.go
@@ -51,6 +51,14 @@ func (m *mockS3) UploadFile(_ context.Context, _ string, _ io.Reader, _ string, 
 	return m.uploadURL, nil
 }
 
+func (m *mockS3) UploadPublicFile(_ context.Context, _ string, _ io.Reader, _ string, _ int64) (string, error) {
+	m.uploadCount++
+	if m.uploadErr != nil {
+		return "", m.uploadErr
+	}
+	return m.uploadURL, nil
+}
+
 func (m *mockS3) GetFile(_ context.Context, _ string) ([]byte, error) {
 	return nil, nil
 }

--- a/apps/api/internal/modules/curator/service.go
+++ b/apps/api/internal/modules/curator/service.go
@@ -2058,6 +2058,8 @@ func (s *Service) GetAttentionList(ctx context.Context, curatorID int64) ([]Atte
 	}
 	clientInfoMap := make(map[int64]clientInfo)
 	inClause, args := buildPlaceholders(clientIDs, 0)
+	// For queries that bind curatorID as $1, client IDs must start at $2.
+	inClauseOffset, clientOffsetArgs := buildPlaceholders(clientIDs, 1)
 
 	infoQuery := fmt.Sprintf(`SELECT id, COALESCE(name, ''), COALESCE(avatar_url, '') FROM users WHERE id IN %s`, inClause)
 	infoRows, err := s.db.QueryContext(ctx, infoQuery, args...)
@@ -2137,9 +2139,8 @@ func (s *Service) GetAttentionList(ctx context.Context, curatorID int64) ([]Atte
 			AND t.user_id IN %s
 		ORDER BY t.due_date ASC
 		LIMIT 20
-	`, inClause)
-	overdueArgs := append([]any{curatorID}, args...)
-	overdueRows, err := s.db.QueryContext(ctx, overdueQuery, overdueArgs...)
+	`, inClauseOffset)
+	overdueRows, err := s.db.QueryContext(ctx, overdueQuery, append([]any{curatorID}, clientOffsetArgs...)...)
 	if err != nil {
 		s.log.Error("Failed to query overdue tasks", "error", err)
 	} else {
@@ -2216,9 +2217,8 @@ func (s *Service) GetAttentionList(ctx context.Context, curatorID int64) ([]Atte
 			AND wr.user_id IN %s
 		ORDER BY wr.submitted_at ASC
 		LIMIT 20
-	`, inClause)
-	feedbackArgs := append([]any{curatorID}, args...)
-	feedbackRows, err := s.db.QueryContext(ctx, feedbackQuery, feedbackArgs...)
+	`, inClauseOffset)
+	feedbackRows, err := s.db.QueryContext(ctx, feedbackQuery, append([]any{curatorID}, clientOffsetArgs...)...)
 	if err != nil {
 		s.log.Error("Failed to query awaiting feedback", "error", err)
 	} else {

--- a/apps/api/internal/shared/storage/s3.go
+++ b/apps/api/internal/shared/storage/s3.go
@@ -94,18 +94,27 @@ func (s *S3Client) prefixKey(key string) string {
 	return s.pathPrefix + key
 }
 
-// UploadFile uploads a file to S3
+// UploadFile uploads a file to S3 with private ACL.
 func (s *S3Client) UploadFile(ctx context.Context, key string, data io.Reader, contentType string, fileSize int64) (string, error) {
+	return s.uploadWithACL(ctx, key, data, contentType, fileSize, "private")
+}
+
+// UploadPublicFile uploads a file to S3 with public-read ACL so it is
+// directly accessible via its URL (e.g. cover images in the content bucket).
+func (s *S3Client) UploadPublicFile(ctx context.Context, key string, data io.Reader, contentType string, fileSize int64) (string, error) {
+	return s.uploadWithACL(ctx, key, data, contentType, fileSize, "public-read")
+}
+
+func (s *S3Client) uploadWithACL(ctx context.Context, key string, data io.Reader, contentType string, fileSize int64, acl s3types.ObjectCannedACL) (string, error) {
 	startTime := time.Now()
 
-	// Upload to S3
 	input := &s3.PutObjectInput{
 		Bucket:        aws.String(s.bucket),
 		Key:           aws.String(s.prefixKey(key)),
 		Body:          data,
 		ContentType:   aws.String(contentType),
 		ContentLength: aws.Int64(fileSize),
-		ACL:           "private", // Private by default
+		ACL:           acl,
 	}
 
 	_, err := s.client.PutObject(ctx, input)
@@ -119,7 +128,6 @@ func (s *S3Client) UploadFile(ctx context.Context, key string, data io.Reader, c
 		return "", fmt.Errorf("failed to upload file to S3: %w", err)
 	}
 
-	// Generate URL
 	url := fmt.Sprintf("%s/%s/%s", s.endpoint, s.bucket, s.prefixKey(key))
 
 	s.log.Info("File uploaded to S3",


### PR DESCRIPTION
## Summary

- **fix(content):** Upload cover images with `public-read` ACL so browser can access them directly. Previously `UploadFile` always used `private` ACL, making new cover image uploads return 403 in prod. Added `UploadPublicFile` method on `S3Client` and updated `UploadCoverImage` to use it.

- **fix(curator):** Correct SQL argument mismatch in `GetAttentionList`. The overdue tasks and awaiting feedback queries used `buildPlaceholders(clientIDs, 0)` (generating `\$1,\$2,...`) but also bound `curatorID` as `\$1`, causing a placeholder collision. With N clients the DB received N+1 args for N placeholders → "expected N arguments, got N+1" error on every curator dashboard page load. Fix: build a second IN clause with offset=1 (`\$2,\$3,...`) for queries that already use `\$1` for `curatorID`.

## Prod errors fixed

```
"msg":"Failed to query overdue tasks","error":"expected 3 arguments, got 4"
"msg":"Failed to query awaiting feedback","error":"expected 3 arguments, got 4"
```

## Test plan

- [x] `go test ./...` — all 23 packages green
- [x] Deployed to `new.burcev.team` — deployment succeeded, health OK
- [x] `GET /api/v1/curator/attention` returns 11 items with no errors (was failing on every call)
- [x] `GET /health` — `{"database":"ok","status":"ok"}`
- [ ] Container logs on prod show no new errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)