### PR TITLE
fix: resolve prod errors and complete content feature

### DIFF
--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -38,7 +38,7 @@ export default async function Image() {
                         maxWidth: 800,
                     }}
                 >
-                    Персональный трекер питания и фитнеса
+                    Personal fitness &amp; nutrition tracker
                 </div>
                 <div
                     style={{

--- a/apps/web/src/shared/components/ServiceWorkerCleanup.tsx
+++ b/apps/web/src/shared/components/ServiceWorkerCleanup.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 
-const SW_CLEANUP_KEY = 'sw-cleanup-v2'
+const SW_CLEANUP_KEY = 'sw-cleanup-v3'
 
 /**
  * One-time nuclear cleanup: unregisters ALL service workers and purges


### PR DESCRIPTION
## Summary

- **fix(curator):** Correct SQL argument mismatch in `GetAttentionList` — `buildPlaceholders` with offset=0 caused `$1` collision when a separate `curator_id = $1` predicate was present; overdue/feedback queries now use offset=1 (`$2,$3,...`)
- **fix(content):** Upload cover images with `public-read` ACL so browsers can fetch them; route through S3 instead of Unsplash; add cover image upload UI
- **fix(web):** OG image Cyrillic text removed (Satori can't fetch Google Fonts on YC servers); ServiceWorkerCleanup key bumped to v3 to flush stale next-pwa cached bundles causing "Failed to find Server Action" errors
- **fix(security):** CSP header in nginx, restrict Gin trusted proxies to RFC1918 ranges, tighten image allowlist
- **fix(db):** Reduce pool size and add connect_timeout for YC PG failover resilience
- **fix(auth):** Fix error extraction in password reset pages after apiClient migration
- **feat(auth):** Enforce password policy across all write paths
- **perf(curator):** Parallelize GetAnalytics and GetClients with errgroup
- **fix(ci):** Restore branch coverage to 79%, resolve all test failures

## Test plan

- [ ] CI green on all checks
- [ ] Prod deployment completes successfully
- [ ] `GET /health` → `{"database":"ok"}` on prod
- [ ] Cover images load in browser on prod
- [ ] Curator attention list returns without SQL errors
- [ ] No OG image font fetch errors in prod web container logs
- [ ] No "Failed to find Server Action" errors in prod web container logs (after client cache flush)

🤖 Generated with [Claude Code](https://claude.com/claude-code)