### PR TITLE
fix(db): retry health check to suppress transient YC DNS/TCP noise

### DIFF
--- a/apps/api/internal/shared/database/postgres.go
+++ b/apps/api/internal/shared/database/postgres.go
@@ -251,16 +251,26 @@ func (db *DB) ExecContext(ctx context.Context, query string, args ...interface{}
 	return db.DB.ExecContext(ctx, query, args...)
 }
 
-// Health checks database health
+// Health checks database health with one retry to survive transient DNS/network blips.
 func (db *DB) Health(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-
-	if err := db.PingContext(ctx); err != nil {
-		return fmt.Errorf("database health check failed: %w", err)
+	const attempts = 2
+	var lastErr error
+	for i := range attempts {
+		pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		lastErr = db.PingContext(pingCtx)
+		cancel()
+		if lastErr == nil {
+			return nil
+		}
+		if i < attempts-1 {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("database health check failed: %w", ctx.Err())
+			case <-time.After(500 * time.Millisecond):
+			}
+		}
 	}
-
-	return nil
+	return fmt.Errorf("database health check failed: %w", lastErr)
 }
 
 // Stats returns database statistics


### PR DESCRIPTION
## Summary

- The Yandex Cloud HA PostgreSQL cluster (`rc1b` + `rc1d`) occasionally causes 2-second DNS or TCP timeouts that generate ERROR-level log noise but don't affect real user requests (the connection pool reuses established connections)
- Added a single retry with 500ms delay in `Health()` before reporting the database as unhealthy — absorbs transient blips without inflating the health check latency meaningfully

## Root cause

`db.PingContext` creates a fresh TCP connection, which can fail when Docker's embedded DNS resolver (`127.0.0.11`) hiccups or when the Yandex Cloud network briefly partitions. These are infra-level transients, not application bugs.

## Test plan

- [ ] `go test ./internal/shared/database/...` green
- [ ] CI green
- [ ] Prod deployment done
- [ ] No spurious `Database health check failed` errors in prod logs during normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)