### PR TITLE
fix(web): reload on SW controllerchange to prevent stale server action IDs

### DIFF
--- a/apps/web/src/shared/components/ServiceWorkerCleanup.tsx
+++ b/apps/web/src/shared/components/ServiceWorkerCleanup.tsx
@@ -4,48 +4,58 @@ import { useEffect } from 'react'
 
 const SW_CLEANUP_KEY = 'sw-cleanup-v3'
 
-/**
- * One-time nuclear cleanup: unregisters ALL service workers and purges
- * ALL caches, then reloads so next-pwa can install a fresh SW with
- * correct NetworkOnly rules for API routes.
- *
- * Uses a localStorage flag so it only runs once per browser profile.
- */
 export function ServiceWorkerCleanup() {
     useEffect(() => {
-        if (typeof window === 'undefined') return
-        if (localStorage.getItem(SW_CLEANUP_KEY)) return
+        if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return
 
-        const cleanup = async () => {
-            let didWork = false
+        // When next-pwa's skipWaiting:true activates a new SW while the old
+        // page is still open, the browser fires 'controllerchange'. At that
+        // point the old JS bundles (with old server-action IDs) are stale, so
+        // we reload immediately to pick up fresh chunks from the new SW.
+        // existingController guard prevents a reload on the very first install
+        // (no previous controller → not an update, just initial activation).
+        const existingController = navigator.serviceWorker.controller
+        let reloading = false
+        const handleControllerChange = () => {
+            if (existingController && !reloading) {
+                reloading = true
+                window.location.reload()
+            }
+        }
+        navigator.serviceWorker.addEventListener('controllerchange', handleControllerChange)
 
-            // Unregister all service workers
-            if ('serviceWorker' in navigator) {
+        // One-time nuclear cleanup: purge stale caches from old next-pwa
+        // installations. Runs once per browser profile, then sets a flag.
+        if (!localStorage.getItem(SW_CLEANUP_KEY)) {
+            const cleanup = async () => {
+                let didWork = false
+
                 const registrations = await navigator.serviceWorker.getRegistrations()
                 for (const reg of registrations) {
                     await reg.unregister()
                     didWork = true
                 }
-            }
 
-            // Delete all caches
-            if ('caches' in window) {
-                const names = await caches.keys()
-                for (const name of names) {
-                    await caches.delete(name)
-                    didWork = true
+                if ('caches' in window) {
+                    const names = await caches.keys()
+                    for (const name of names) {
+                        await caches.delete(name)
+                        didWork = true
+                    }
+                }
+
+                localStorage.setItem(SW_CLEANUP_KEY, Date.now().toString())
+
+                if (didWork) {
+                    window.location.reload()
                 }
             }
-
-            localStorage.setItem(SW_CLEANUP_KEY, Date.now().toString())
-
-            if (didWork) {
-                console.log('[SW-Cleanup] Unregistered old SWs and purged caches, reloading...')
-                window.location.reload()
-            }
+            cleanup()
         }
 
-        cleanup()
+        return () => {
+            navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange)
+        }
     }, [])
 
     return null

--- a/apps/web/src/shared/components/__tests__/ServiceWorkerCleanup.test.tsx
+++ b/apps/web/src/shared/components/__tests__/ServiceWorkerCleanup.test.tsx
@@ -1,0 +1,90 @@
+import { render } from '@testing-library/react'
+import { ServiceWorkerCleanup } from '../ServiceWorkerCleanup'
+
+const mockAddEventListener = jest.fn()
+const mockRemoveEventListener = jest.fn()
+
+function makeSwApi(controller: object | null = null, registrations: object[] = []) {
+    return {
+        controller,
+        addEventListener: mockAddEventListener,
+        removeEventListener: mockRemoveEventListener,
+        getRegistrations: jest.fn().mockResolvedValue(registrations),
+    }
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    Object.defineProperty(navigator, 'serviceWorker', {
+        value: makeSwApi(),
+        writable: true,
+        configurable: true,
+    })
+})
+
+describe('ServiceWorkerCleanup', () => {
+    it('renders null', () => {
+        const { container } = render(<ServiceWorkerCleanup />)
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('registers controllerchange listener on mount', () => {
+        render(<ServiceWorkerCleanup />)
+        expect(mockAddEventListener).toHaveBeenCalledWith('controllerchange', expect.any(Function))
+    })
+
+    it('removes controllerchange listener on unmount', () => {
+        const { unmount } = render(<ServiceWorkerCleanup />)
+        unmount()
+        expect(mockRemoveEventListener).toHaveBeenCalledWith('controllerchange', expect.any(Function))
+    })
+
+    it('handler is a no-op when there was no prior controller', () => {
+        render(<ServiceWorkerCleanup />)
+        // existingController is null → no reload
+        const handler = mockAddEventListener.mock.calls.find(
+            ([event]: [string]) => event === 'controllerchange'
+        )?.[1]
+        expect(() => handler?.()).not.toThrow()
+    })
+
+    it('handler triggers reload branch when a prior controller exists', () => {
+        Object.defineProperty(navigator, 'serviceWorker', {
+            value: makeSwApi({ scriptURL: 'sw.js' }),
+            writable: true,
+            configurable: true,
+        })
+        render(<ServiceWorkerCleanup />)
+        // existingController !== null → handler enters the reload branch
+        const handler = mockAddEventListener.mock.calls.find(
+            ([event]: [string]) => event === 'controllerchange'
+        )?.[1]
+        expect(() => handler?.()).not.toThrow()
+    })
+
+    it('unregisters SWs on first render when localStorage flag is absent', async () => {
+        const mockUnregister = jest.fn().mockResolvedValue(true)
+        Object.defineProperty(navigator, 'serviceWorker', {
+            value: makeSwApi(null, [{ unregister: mockUnregister }]),
+            writable: true,
+            configurable: true,
+        })
+        render(<ServiceWorkerCleanup />)
+        await new Promise(r => setTimeout(r, 0))
+        expect(mockUnregister).toHaveBeenCalled()
+    })
+
+    it('skips cleanup when localStorage flag is already set', async () => {
+        localStorage.setItem('sw-cleanup-v3', Date.now().toString())
+        const mockUnregister = jest.fn()
+        Object.defineProperty(navigator, 'serviceWorker', {
+            value: makeSwApi(null, [{ unregister: mockUnregister }]),
+            writable: true,
+            configurable: true,
+        })
+        render(<ServiceWorkerCleanup />)
+        await new Promise(r => setTimeout(r, 0))
+        expect(mockUnregister).not.toHaveBeenCalled()
+    })
+})

--- a/eslint.security.config.mjs
+++ b/eslint.security.config.mjs
@@ -4,6 +4,7 @@
  */
 
 import js from '@eslint/js';
+import globals from 'globals';
 
 const securityConfig = [
     js.configs.recommended,
@@ -52,7 +53,7 @@ const securityConfig = [
         }
     },
     {
-        // Relaxed rules for test files — add Jest globals so no-undef doesn't fire
+        // Relaxed rules for test files — add Jest + browser globals so no-undef doesn't fire
         files: [
             '**/*.test.{js,ts,jsx,tsx}',
             '**/*.spec.{js,ts,jsx,tsx}',
@@ -60,15 +61,8 @@ const securityConfig = [
         ],
         languageOptions: {
             globals: {
-                describe: 'readonly',
-                it: 'readonly',
-                test: 'readonly',
-                expect: 'readonly',
-                beforeAll: 'readonly',
-                afterAll: 'readonly',
-                beforeEach: 'readonly',
-                afterEach: 'readonly',
-                jest: 'readonly',
+                ...globals.browser,
+                ...globals.jest,
             }
         },
         rules: {

--- a/eslint.security.config.mjs
+++ b/eslint.security.config.mjs
@@ -52,12 +52,25 @@ const securityConfig = [
         }
     },
     {
-        // Relaxed rules for test files
+        // Relaxed rules for test files — add Jest globals so no-undef doesn't fire
         files: [
             '**/*.test.{js,ts,jsx,tsx}',
             '**/*.spec.{js,ts,jsx,tsx}',
             'src/__tests__/**/*.{js,ts,jsx,tsx}'
         ],
+        languageOptions: {
+            globals: {
+                describe: 'readonly',
+                it: 'readonly',
+                test: 'readonly',
+                expect: 'readonly',
+                beforeAll: 'readonly',
+                afterAll: 'readonly',
+                beforeEach: 'readonly',
+                afterEach: 'readonly',
+                jest: 'readonly',
+            }
+        },
         rules: {
             'no-console': 'off'
         }


### PR DESCRIPTION
## Summary

- **Root cause**: `next-pwa` is configured with `skipWaiting: true`, which means a new service worker immediately takes over when a new deployment happens. Open tabs still running old JS bundles then send stale server-action IDs to the new server → "Failed to find Server Action" errors.
- **Fix**: Listen for `controllerchange` on `navigator.serviceWorker`. When a new SW takes over an existing controller, reload immediately. This forces the tab to pick up fresh JS chunks from the new bundle, eliminating stale action IDs.
- **Guard**: `existingController` check prevents a spurious reload on the very first install (no previous controller = initial activation, not an update).

## Why the previous SW cleanup fix wasn't enough

`ServiceWorkerCleanup` (v3 key) purges caches on first visit — it handles users who have stale cached files from old builds. But it doesn't handle the **live takeover scenario**: a user has an open tab, a new deployment happens, and `skipWaiting:true` activates the new SW while the old JS is still running in memory. The `controllerchange` listener catches exactly this.

## Test plan

- [ ] CI green
- [ ] Prod deployment done
- [ ] No more "Failed to find Server Action" errors in prod web container logs after deployment
- [ ] Opening the app in an old tab and deploying causes the tab to auto-reload (verify manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)